### PR TITLE
html output lang attribute fix

### DIFF
--- a/src/Hook/HtmlOutput.php
+++ b/src/Hook/HtmlOutput.php
@@ -36,7 +36,10 @@ class HtmlOutput extends AbstractHook
         $preConfig = libxml_use_internal_errors(true);
         $html = $params['html'];
         $doc = new \DOMDocument();
-        $doc->loadHTML('<meta http-equiv="Content-Type" content="charset=utf-8">' . $html);
+        $doc->loadHTML(
+            '<meta http-equiv="Content-Type" content="charset=utf-8">' . $html,
+            LIBXML_NOERROR | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
         $links = $doc->getElementsByTagName('link');
 
         foreach ($links as $link) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Fixing missing lang attribute in html tag due to replacing original doc tag with new one. 
| Type?             | bug fix 
| Fixed ticket?     | https://github.com/Oksydan/falcon/issues/277
