### PR TITLE
Update Header.php

### DIFF
--- a/src/Hook/Header.php
+++ b/src/Hook/Header.php
@@ -17,8 +17,21 @@ use Oksydan\Module\IsThemeCore\Form\Settings\WebpConfiguration;
 class Header extends AbstractHook
 {
     public const HOOK_LIST = [
+        'actionFrontControllerInitBefore',
         'displayHeader',
     ];
+
+    public function hookActionFrontControllerInitBefore(): void
+    {
+        $themeListDisplay = new ThemeListDisplay();
+        $this->context->smarty->assign([
+            'listingDisplayType' => $themeListDisplay->getDisplay(),
+            'preloadCss' => \Configuration::get(GeneralConfiguration::THEMECORE_PRELOAD_CSS),
+            'webpEnabled' => \Configuration::get(WebpConfiguration::THEMECORE_WEBP_ENABLED),
+            'loadPartytown' => (bool) \Configuration::get(GeneralConfiguration::THEMECORE_LOAD_PARTY_TOWN),
+            'debugPartytown' => (bool) \Configuration::get(GeneralConfiguration::THEMECORE_DEBUG_PARTY_TOWN),
+        ]);
+    }
 
     public function hookDisplayHeader(): string
     {
@@ -32,12 +45,7 @@ class Header extends AbstractHook
         }
 
         $this->context->smarty->assign([
-            'listingDisplayType' => $themeListDisplay->getDisplay(),
-            'preloadCss' => \Configuration::get(GeneralConfiguration::THEMECORE_PRELOAD_CSS),
-            'webpEnabled' => \Configuration::get(WebpConfiguration::THEMECORE_WEBP_ENABLED),
             'jsonData' => $this->getStructuredData(),
-            'loadPartytown' => (bool) \Configuration::get(GeneralConfiguration::THEMECORE_LOAD_PARTY_TOWN),
-            'debugPartytown' => (bool) \Configuration::get(GeneralConfiguration::THEMECORE_DEBUG_PARTY_TOWN),
             'partytownScript' => $this->getPartytownScript(),
             'partytownScriptUri' => $this->getPartytownScriptUri(),
         ]);


### PR DESCRIPTION
Moving smarty variables from displayHeader to actionFrontControllerInitBefore because we needed it for modules that replace product list items witout reloading ([Amazzing Filter](https://addons.prestashop.com/en/search-filters/18575-amazzing-filter.html) in our case)


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description      | Moving smarty variables from displayHeader to actionFrontControllerInitBefore because we needed it for modules that replace product list items witout reloading ([Amazzing Filter](https://addons.prestashop.com/en/search-filters/18575-amazzing-filter.html) in our case)
| Type             | bug fix 

If you need any further information, please do not hesitate to contact me.