### PR TITLE
BUGFIX : lost content in .htaccess file

### DIFF
--- a/src/Core/Htaccess/HtaccessGenerator.php
+++ b/src/Core/Htaccess/HtaccessGenerator.php
@@ -36,6 +36,9 @@ class HtaccessGenerator
             if (preg_match('#^(.*)\# ' . $this->wrapperBlockComments['COMMENT_START'] . '.*\# ' . $this->wrapperBlockComments['COMMENT_END'] . '[^\n]*(.*)$#s', $content, $match)) {
                 $this->contentBefore = $match[1];
                 $this->contentAfter = $match[2];
+                if( !empty($this->contentBefore)) {
+                    $this->write($this->contentBefore);
+                }
             } else {
                 $this->contentAfter = $content;
             }


### PR DESCRIPTION
If there is content before "~~start-is_themecore~~", it's lost when .htaccess file is regenerated.
