### PR TITLE
Fix : Module "pm_advancedsearch4" needs jQueryUi for price slider

### DIFF
--- a/src/Hook/Assets.php
+++ b/src/Hook/Assets.php
@@ -20,9 +20,13 @@ class Assets extends AbstractHook
         $this->context->controller->unregisterJavascript('facetedsearch_front');
         $this->context->controller->unregisterStylesheet('facetedsearch_front');
 
-        $this->context->controller->unregisterJavascript('jquery-ui');
-        $this->context->controller->unregisterStylesheet('jquery-ui');
-        $this->context->controller->unregisterStylesheet('jquery-ui-theme');
+        $needsJQueryUi = \Module::isEnabled('pm_advancedsearch4') && $this->context->controller instanceof \ProductListingFrontController;
+
+        if (!$needsJQueryUi) {
+            $this->context->controller->unregisterJavascript('jquery-ui');
+            $this->context->controller->unregisterStylesheet('jquery-ui');
+            $this->context->controller->unregisterStylesheet('jquery-ui-theme');
+        }
     }
 
     public function hookActionFrontControllerSetMedia()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | The "pm_advancedsearch4" module (Advanced Search PRO) can display a price slider in product listing pages, this slider needs jQueryUi. However the module "is_themecore" removes jQueryUi. This PR is just a quick bugfix, in hopes that the developper of the "pm_advancedsearch4" module will not rely on jQueryUI for the slider
| Type?             | bug fix
| Fixed ticket?     | https://github.com/Oksydan/falcon/issues/379

